### PR TITLE
CTPL-278 - Duplicate callslip printing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM nla-registry-quay-quay.apps.dev-containers.nla.gov.au/nla/ubi8-openjdk-17:latest
+FROM nla-registry-quay-quay.apps.dev-containers.nla.gov.au/nla/ubi8-openjdk-21:latest
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} /app/app.jar
 ENTRYPOINT ["bash", "-c", "java ${JAVA_OPTS} -DfolioConfigMap=\"{ FOLIO_OKAPI_URL:  '$FOLIO_OKAPI_URL', FOLIO_TENANT: '$FOLIO_TENANT', FOLIO_USERNAME: '$FOLIO_USERNAME', FOLIO_PASSWORD: '$FOLIO_PASSWORD' }\" -jar /app/app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 nlaBuild steps: this,
     applicationName: "folio-pickslip-viewer",
-    jdk: 'JDK 17',
+    jdk: 'JDK 21',
     deployToDev: false,
     devHostname: "spade",
     deployToNexus: true,

--- a/pom.xml
+++ b/pom.xml
@@ -6,16 +6,16 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.1</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>au.gov.nla</groupId>
 	<artifactId>folio-pickslip-viewer</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<name>folio-pickslip-viewer</name>
 	<description>FOLIO pickslip / request queue viewer</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 	</properties>
@@ -62,10 +62,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -83,10 +79,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-authorization-server</artifactId>
 		</dependency>
-		<!--dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-oauth2-client</artifactId>
-		</dependency-->
 
 		<dependency>
 			<groupId>org.webjars</groupId>
@@ -122,7 +114,7 @@
 		<dependency>
 			<groupId>au.gov.nla</groupId>
 			<artifactId>folio-api</artifactId>
-			<version>1.0.21-RELEASE</version>
+			<version>1.0.23-RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/au/gov/nla/pickslip/service/PdfResponderService.java
+++ b/src/main/java/au/gov/nla/pickslip/service/PdfResponderService.java
@@ -33,7 +33,7 @@ public class PdfResponderService {
 
   @Autowired UnicodeFontMap unicodeFontMap;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
   private ITextRenderer renderer;
 
@@ -68,7 +68,7 @@ public class PdfResponderService {
 
     Code128Writer barcodeWriter = new Code128Writer();
 
-    Map<EncodeHintType, Object> hints = new EnumMap<EncodeHintType, Object>(EncodeHintType.class);
+    Map<EncodeHintType, Object> hints = new EnumMap<>(EncodeHintType.class);
     hints.put(EncodeHintType.CHARACTER_SET, "UTF-8");
     hints.put(EncodeHintType.MARGIN, 4);
 
@@ -80,7 +80,7 @@ public class PdfResponderService {
     return Base64.getEncoder().encodeToString(bos.toByteArray());
   }
 
-  public synchronized void generate(OutputStream os, List<PickslipQueues.Pickslip> pickslipList) {
+  public synchronized void generate(OutputStream os, List<PickslipQueues.Pickslip> pickslipList, String filename) {
 
     Context ctx = new Context(LocaleContextHolder.getLocale());
 
@@ -114,6 +114,7 @@ public class PdfResponderService {
 
         ctx.setVariable("instance", instances.get(pickslip.instance().id()));
         ctx.setVariable("pickslip", pickslip);
+        ctx.setVariable("printFilename", filename);
         ctx.setVariable("unicodeFontMap", unicodeFontMap);
 
         String htmlContent = this.templateEngine.process("pdf/print_pdf", ctx);

--- a/src/main/resources/templates/pdf/print_pdf.html
+++ b/src/main/resources/templates/pdf/print_pdf.html
@@ -106,7 +106,8 @@
                 <div class="access-info">
                     <table>
                         <tr> <td class="label-left">Access conditions:</td> <td class="heavy-font" th:text="${#strings.abbreviate(instance.accessConditions,100)} ?: '-'"/> </tr>
-                        <tr> <td class="label-left">Terms of use:</td>      <td class="heavy-font" th:text="${#strings.abbreviate(instance.termsOfUse,100)} ?: '-'"/> </tr>
+                        <tr> <td class="label-left">Terms of use:</td>      <td class="heavy-font" th:text="${#strings.abbreviate(instance.termsOfUse,40)} ?: '-'"/> </tr>
+                        <tr> <td class="label-left">Ref:</td>      <td class="heavy-font" th:text="${#strings.abbreviate(printFilename,100)} ?: '-'"/> </tr>
                     </table>
                 </div>
             </div>


### PR DESCRIPTION
This change is to assist in the investigation of duplicate callslip printing.

Generates a descriptive pdf download filename for bulk and individual callslip print files, and includes the filename in the shelf copy of the callslip. Also updates Java, Springboot and folio API versions.